### PR TITLE
Upgrade target framework and package references in prime-service

### DIFF
--- a/src/services/prime-service/Program.cs
+++ b/src/services/prime-service/Program.cs
@@ -1,5 +1,3 @@
-using Microsoft.OpenApi.Models;
-
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddControllers();

--- a/src/services/prime-service/prime-service.csproj
+++ b/src/services/prime-service/prime-service.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <UserSecretsId>0f4c7356-7e21-4dfc-8204-39d39703e96d</UserSecretsId>
@@ -8,7 +8,7 @@
         <DockerfileContext>.</DockerfileContext>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.22.0" />
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.4" />
+        <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="10.0.1" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
- Update the target framework from net9.0 to net10.0 to leverage new features and improvements.

- Upgrade Microsoft.VisualStudio.Azure.Containers.Tools.Targets package to version 1.23.0 for enhanced functionality.

- Upgrade Swashbuckle.AspNetCore package to version 10.0.1 for better API documentation support.

- Remove unused directive for Microsoft.OpenApi.Models to clean up the code.