### PR TITLE
Add note on recommended branching strategy for GitHub Flow

### DIFF
--- a/demos/01-enterprise-devops/05-branching-types/readme.md
+++ b/demos/01-enterprise-devops/05-branching-types/readme.md
@@ -10,6 +10,8 @@
 
 ![GitHub Flow branching model showing a simple main branch with feature branches](_images/github-flow.jpg)
 
+>Note: This is the recommended branching strategy for GitHub repositories, and is widely used in open source projects and teams practicing continuous delivery.
+
 **Overview** — GitHub Flow is a lightweight branching model designed for continuous deployment. Create feature branches from main, commit changes, open a pull request for review, and merge back to main when approved. Every merge to main should be deployable.
 
 **Key characteristics:**


### PR DESCRIPTION
- Emphasizes GitHub Flow as the recommended branching strategy for GitHub repositories.

- Highlights its popularity in open source projects and among teams practicing continuous delivery.

- Aims to provide clarity and guidance on best practices for users regarding branching strategies.