### PR TITLE
Fix typo in GitFlow link in README

### DIFF
--- a/demos/01-enterprise-devops/05-branching-types/readme.md
+++ b/demos/01-enterprise-devops/05-branching-types/readme.md
@@ -71,7 +71,7 @@ git flow release finish <RELEASE>
 
 ## Links & Resources
 
-[GitFlow Cheatsheet](https://danielkummer.github.io/git-flow-cheatsheet/)
+[GitFlow Cheat sheet](https://danielkummer.github.io/git-flow-cheatsheet/)
 
 [GitHub Flow Documentation](https://docs.github.com/en/get-started/quickstart/github-flow)
 


### PR DESCRIPTION
- Changed "GitFlow Cheatsheet" to "GitFlow Cheat sheet" for consistency.
- Ensured proper naming convention in the Links & Resources section.