### PR TITLE
Fix typo in README and add build pipeline for Python function

### DIFF
--- a/.azdo/build-py.yml
+++ b/.azdo/build-py.yml
@@ -1,0 +1,33 @@
+name: "build-py"
+
+trigger: none
+pr: none
+
+variables:
+  pythonVersion: "3.12"
+
+stages:
+  - stage: Build
+    displayName: Build Python Function
+    jobs:
+      - job: Build
+        pool:
+          vmImage: ubuntu-latest
+        steps:
+          - task: UsePythonVersion@0
+            inputs:
+              versionSpec: $(pythonVersion)
+          - script: |
+              python -m pip install --upgrade pip
+              pip install -r src/az-functions/payment-py/requirements.txt
+            displayName: Install dependencies
+          - task: ArchiveFiles@2
+            displayName: Archive function app
+            inputs:
+              rootFolderOrFile: src/az-functions/payment-py
+              includeRootFolder: false
+              archiveType: zip
+              archiveFile: $(Build.ArtifactStagingDirectory)/payment-py.zip
+              replaceExistingArchive: true
+          - publish: $(Build.ArtifactStagingDirectory)/payment-py.zip
+            artifact: functionapp

--- a/demos/01-enterprise-devops/05-branching-types/readme.md
+++ b/demos/01-enterprise-devops/05-branching-types/readme.md
@@ -71,7 +71,7 @@ git flow release finish <RELEASE>
 
 ## Links & Resources
 
-[GitFlow Cheat sheet](https://danielkummer.github.io/git-flow-cheatsheet/)
+[GitFlow Cheat Sheet](https://danielkummer.github.io/git-flow-cheatsheet/)
 
 [GitHub Flow Documentation](https://docs.github.com/en/get-started/quickstart/github-flow)
 


### PR DESCRIPTION
- Corrected the capitalization of "Cheat sheet" to "Cheat Sheet" in the Links & Resources section for consistency and professionalism.

- Introduced a new build pipeline configuration for a Python function, enabling manual execution with specified Python version 3.12.

- Configured the pipeline to install dependencies, archive the function app, and publish it as an artifact.